### PR TITLE
카테고리 관리 화면 구현

### DIFF
--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */; };
 		AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */; };
 		AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FB293E28F80023E453 /* CategoryListView.swift */; };
+		AB5AB0FE293E2CA30023E453 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
 		AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchBar.swift; sourceTree = "<group>"; };
 		AB5AB0FB293E28F80023E453 /* CategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListView.swift; sourceTree = "<group>"; };
+		AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,8 +153,9 @@
 		AB5AB0F1293E01600023E453 /* CategoryListView */ = {
 			isa = PBXGroup;
 			children = (
-				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
 				AB5AB0FB293E28F80023E453 /* CategoryListView.swift */,
+				AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */,
+				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
 			);
 			path = CategoryListView;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 				AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */,
 				AB204299293B93940086DA36 /* CoreDataManager.swift in Sources */,
 				AB393174293C6CC00051454D /* Category+.swift in Sources */,
+				AB5AB0FE293E2CA30023E453 /* CategoryViewModel.swift in Sources */,
 				AB20426A293B666A0086DA36 /* LifeWrongAnswerNoteApp.swift in Sources */,
 				AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */,
 				AB393152293C65280051454D /* NSManagedObject+.swift in Sources */,

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AB39317C293CB41D0051454D /* Assessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39317B293CB41D0051454D /* Assessment.swift */; };
 		AB39317E293CCB300051454D /* Choice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39317D293CCB300051454D /* Choice+.swift */; };
 		AB393182293CCB6A0051454D /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB393181293CCB6A0051454D /* ChoiceTests.swift */; };
+		AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		AB39317B293CB41D0051454D /* Assessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assessment.swift; sourceTree = "<group>"; };
 		AB39317D293CCB300051454D /* Choice+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Choice+.swift"; sourceTree = "<group>"; };
 		AB393181293CCB6A0051454D /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
+		AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +93,7 @@
 		AB204268293B666A0086DA36 /* LifeWrongAnswerNote */ = {
 			isa = PBXGroup;
 			children = (
+				AB5AB0F0293E003C0023E453 /* Views */,
 				AB204292293B8A640086DA36 /* Models */,
 				AB204269293B666A0086DA36 /* LifeWrongAnswerNoteApp.swift */,
 				AB20426B293B666A0086DA36 /* ContentView.swift */,
@@ -130,6 +133,22 @@
 				AB393181293CCB6A0051454D /* ChoiceTests.swift */,
 			);
 			path = LifeWrongAnswerNoteTests;
+			sourceTree = "<group>";
+		};
+		AB5AB0F0293E003C0023E453 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				AB5AB0F1293E01600023E453 /* CategoryListView */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		AB5AB0F1293E01600023E453 /* CategoryListView */ = {
+			isa = PBXGroup;
+			children = (
+				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
+			);
+			path = CategoryListView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -234,6 +253,7 @@
 			files = (
 				AB204295293B8A730086DA36 /* ProblemModel.xcdatamodeld in Sources */,
 				AB39317E293CCB300051454D /* Choice+.swift in Sources */,
+				AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */,
 				AB39317C293CB41D0051454D /* Assessment.swift in Sources */,
 				AB393176293C8A4E0051454D /* Problem+.swift in Sources */,
 				AB20426C293B666A0086DA36 /* ContentView.swift in Sources */,

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */; };
 		AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FB293E28F80023E453 /* CategoryListView.swift */; };
 		AB5AB0FE293E2CA30023E453 /* CategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */; };
+		AB9F3DC4293F4C45002C9785 /* CategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9F3DC3293F4C45002C9785 /* CategoryListViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 		AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchBar.swift; sourceTree = "<group>"; };
 		AB5AB0FB293E28F80023E453 /* CategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListView.swift; sourceTree = "<group>"; };
 		AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewModel.swift; sourceTree = "<group>"; };
+		AB9F3DC3293F4C45002C9785 /* CategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +158,7 @@
 				AB5AB0FB293E28F80023E453 /* CategoryListView.swift */,
 				AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */,
 				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
+				AB9F3DC3293F4C45002C9785 /* CategoryListViewModel.swift */,
 			);
 			path = CategoryListView;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				AB204299293B93940086DA36 /* CoreDataManager.swift in Sources */,
 				AB393174293C6CC00051454D /* Category+.swift in Sources */,
 				AB5AB0FE293E2CA30023E453 /* CategoryViewModel.swift in Sources */,
+				AB9F3DC4293F4C45002C9785 /* CategoryListViewModel.swift in Sources */,
 				AB20426A293B666A0086DA36 /* LifeWrongAnswerNoteApp.swift in Sources */,
 				AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */,
 				AB393152293C65280051454D /* NSManagedObject+.swift in Sources */,

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -472,7 +472,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		AB39317E293CCB300051454D /* Choice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39317D293CCB300051454D /* Choice+.swift */; };
 		AB393182293CCB6A0051454D /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB393181293CCB6A0051454D /* ChoiceTests.swift */; };
 		AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */; };
+		AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +53,7 @@
 		AB39317D293CCB300051454D /* Choice+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Choice+.swift"; sourceTree = "<group>"; };
 		AB393181293CCB6A0051454D /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
 		AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
+		AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +140,7 @@
 		AB5AB0F0293E003C0023E453 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				AB5AB0F8293E27100023E453 /* Components */,
 				AB5AB0F1293E01600023E453 /* CategoryListView */,
 			);
 			path = Views;
@@ -149,6 +152,14 @@
 				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
 			);
 			path = CategoryListView;
+			sourceTree = "<group>";
+		};
+		AB5AB0F8293E27100023E453 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -260,6 +271,7 @@
 				AB204299293B93940086DA36 /* CoreDataManager.swift in Sources */,
 				AB393174293C6CC00051454D /* Category+.swift in Sources */,
 				AB20426A293B666A0086DA36 /* LifeWrongAnswerNoteApp.swift in Sources */,
+				AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */,
 				AB393152293C65280051454D /* NSManagedObject+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -155,10 +155,10 @@
 		AB5AB0F1293E01600023E453 /* CategoryListView */ = {
 			isa = PBXGroup;
 			children = (
+				AB9F3DC3293F4C45002C9785 /* CategoryListViewModel.swift */,
 				AB5AB0FB293E28F80023E453 /* CategoryListView.swift */,
 				AB5AB0FD293E2CA30023E453 /* CategoryViewModel.swift */,
 				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
-				AB9F3DC3293F4C45002C9785 /* CategoryListViewModel.swift */,
 			);
 			path = CategoryListView;
 			sourceTree = "<group>";

--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		AB393182293CCB6A0051454D /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB393181293CCB6A0051454D /* ChoiceTests.swift */; };
 		AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */; };
 		AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */; };
+		AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FB293E28F80023E453 /* CategoryListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,7 @@
 		AB393181293CCB6A0051454D /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
 		AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
 		AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchBar.swift; sourceTree = "<group>"; };
+		AB5AB0FB293E28F80023E453 /* CategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */,
+				AB5AB0FB293E28F80023E453 /* CategoryListView.swift */,
 			);
 			path = CategoryListView;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				AB39317C293CB41D0051454D /* Assessment.swift in Sources */,
 				AB393176293C8A4E0051454D /* Problem+.swift in Sources */,
 				AB20426C293B666A0086DA36 /* ContentView.swift in Sources */,
+				AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */,
 				AB204299293B93940086DA36 /* CoreDataManager.swift in Sources */,
 				AB393174293C6CC00051454D /* Category+.swift in Sources */,
 				AB20426A293B666A0086DA36 /* LifeWrongAnswerNoteApp.swift in Sources */,

--- a/LifeWrongAnswerNote/LifeWrongAnswerNoteApp.swift
+++ b/LifeWrongAnswerNote/LifeWrongAnswerNoteApp.swift
@@ -15,7 +15,7 @@ struct LifeWrongAnswerNoteApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            CategoryListView()
         }
     }
 }

--- a/LifeWrongAnswerNote/Models/NSManagedObject+.swift
+++ b/LifeWrongAnswerNote/Models/NSManagedObject+.swift
@@ -16,6 +16,12 @@ extension NSManagedObject {
     func delete() {
         Self.viewContext.delete(self)
     }
+    
+    static func all<T>() throws -> [T] where T: NSManagedObject {
+        let fetchRequest: NSFetchRequest<T> = NSFetchRequest(entityName: String(describing: T.self))
+        
+        return try viewContext.fetch(fetchRequest)
+    }
 }
 
 // https://www.udemy.com/course/core-data-in-ios/

--- a/LifeWrongAnswerNote/Models/NSManagedObject+.swift
+++ b/LifeWrongAnswerNote/Models/NSManagedObject+.swift
@@ -17,6 +17,10 @@ extension NSManagedObject {
         Self.viewContext.delete(self)
     }
     
+    static func by<T> (id: NSManagedObjectID) throws -> T? where T: NSManagedObject {
+        return try viewContext.existingObject(with: id) as? T
+    }
+    
     static func all<T>() throws -> [T] where T: NSManagedObject {
         let fetchRequest: NSFetchRequest<T> = NSFetchRequest(entityName: String(describing: T.self))
         

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -17,8 +17,13 @@ struct CategoryListView: View {
                     .padding(.horizontal, 16)
                 ScrollView {
                     VStack(spacing: 20) {
-                        ForEach(categoryListVM.categoryVMs) { categoryVM in
-                            CategoryRow(categoryVM: categoryVM, onModify: {}, onDelete: {})
+                        ForEach(categoryListVM.enumeratedCategoryVMs, id: \.0) { index, categoryVM in
+                            CategoryRow(categoryVM: categoryVM, onModify: {
+                                categoryListVM.modifyingIndex = index
+                                categoryListVM.modifyNameAlertIsPresented = true
+                            }, onDelete: {
+                                
+                            })
                         }
                     }
                     .padding(.horizontal, 16)
@@ -36,6 +41,28 @@ struct CategoryListView: View {
 
                 }
             }
+        }
+        .alert("에러 발생", isPresented: $categoryListVM.errorAlertIsPresented, actions: {
+            Button("확인") {
+                categoryListVM.errorAlertIsPresented = false
+            }
+        }, message: {
+            Text(categoryListVM.errorMessage)
+        })
+        .alert("카테고리 이름 수정", isPresented: $categoryListVM.modifyNameAlertIsPresented, actions: {
+            TextField("이름 입력", text: $categoryListVM.modifiedCategoryName)
+            Button("취소", role: .cancel, action: {
+                categoryListVM.modifyNameAlertIsPresented = false
+            })
+            Button("확인", action: {
+                categoryListVM.modifyNameAlertIsPresented = false
+                categoryListVM.modifyName()
+            })
+        }, message: {
+            Text("카테고리의 새 이름을 입력하세요.")
+        })
+        .onAppear {
+            categoryListVM.showAllCategories()
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -35,7 +35,7 @@ struct CategoryListView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        categoryListVM.addCategories(named: "categoryEx")
+                        categoryListVM.addCategoryAlertIsPresented = true
                     } label: {
                         Image(systemName: "plus")
                     }
@@ -43,6 +43,22 @@ struct CategoryListView: View {
                 }
             }
         }
+        .onAppear {
+            categoryListVM.showAllCategories()
+        }
+        .alert("카테고리 추가", isPresented: $categoryListVM.addCategoryAlertIsPresented, actions: {
+            TextField("이름 입력", text: $categoryListVM.newCategoryName)
+            Button("추가") {
+                categoryListVM.addCategoryAlertIsPresented = false
+                categoryListVM.addCategory()
+            }
+            
+            Button("취소", role: .cancel) {
+                categoryListVM.addCategoryAlertIsPresented = false
+            }
+        }, message: {
+            Text("새롭게 추가할 카테고리의 이름을 입력하세요.")
+        })
         .alert("에러 발생", isPresented: $categoryListVM.errorAlertIsPresented, actions: {
             Button("확인") {
                 categoryListVM.errorAlertIsPresented = false
@@ -63,9 +79,6 @@ struct CategoryListView: View {
         }, message: {
             Text("카테고리의 새 이름을 입력하세요.")
         })
-        .onAppear {
-            categoryListVM.showAllCategories()
-        }
         .alert("카테고리 제거", isPresented: $categoryListVM.deleteAlertIsPresented, actions: {
             Button("취소", role: .cancel, action: {
                 categoryListVM.modifyNameAlertIsPresented = false

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -22,7 +22,8 @@ struct CategoryListView: View {
                                 categoryListVM.modifyingIndex = index
                                 categoryListVM.modifyNameAlertIsPresented = true
                             }, onDelete: {
-                                
+                                categoryListVM.deletingIndex = index
+                                categoryListVM.deleteAlertIsPresented = true
                             })
                         }
                     }
@@ -51,19 +52,30 @@ struct CategoryListView: View {
         })
         .alert("카테고리 이름 수정", isPresented: $categoryListVM.modifyNameAlertIsPresented, actions: {
             TextField("이름 입력", text: $categoryListVM.modifiedCategoryName)
-            Button("취소", role: .cancel, action: {
+            Button("취소", role: .cancel) {
                 categoryListVM.modifyNameAlertIsPresented = false
-            })
-            Button("확인", action: {
+            }
+            
+            Button("수정") {
                 categoryListVM.modifyNameAlertIsPresented = false
                 categoryListVM.modifyName()
-            })
+            }
         }, message: {
             Text("카테고리의 새 이름을 입력하세요.")
         })
         .onAppear {
             categoryListVM.showAllCategories()
         }
+        .alert("카테고리 제거", isPresented: $categoryListVM.deleteAlertIsPresented, actions: {
+            Button("취소", role: .cancel, action: {
+                categoryListVM.modifyNameAlertIsPresented = false
+            })
+            
+            Button("제거", role: .destructive) {
+                categoryListVM.modifyNameAlertIsPresented = false
+                categoryListVM.deleteCategory()
+            }
+        })
     }
 }
 

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -17,9 +17,7 @@ struct CategoryListView: View {
                     .padding(.horizontal, 16)
                 ScrollView {
                     VStack(spacing: 20) {
-                        ForEach(0..<10) { _ in
-                            CategoryRow()
-                        }
+                        
                     }
                     .padding(.horizontal, 16)
                 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -1,0 +1,38 @@
+//
+//  CategoryListView.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/05.
+//
+
+import SwiftUI
+
+struct CategoryListView: View {
+    @State private var searchText = ""
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                CustomSearchBar(searchText: $searchText, placeholder: "제목으로 검색")
+                    .padding(.horizontal, 16)
+                ScrollView {
+                    VStack(spacing: 20) {
+                        ForEach(0..<10) { _ in
+                            CategoryRow()
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+
+            .navigationTitle("카테고리 관리")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct CategoryListView_Previews: PreviewProvider {
+    static var previews: some View {
+        CategoryListView()
+    }
+}

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -15,19 +15,30 @@ struct CategoryListView: View {
             VStack(spacing: 20) {
                 CustomSearchBar(searchText: $categoryListVM.searchText, placeholder: "제목으로 검색")
                     .padding(.horizontal, 16)
-                ScrollView {
-                    VStack(spacing: 20) {
-                        ForEach(categoryListVM.enumeratedCategoryVMs, id: \.0) { index, categoryVM in
-                            CategoryRow(categoryVM: categoryVM, onModify: {
-                                categoryListVM.modifyingIndex = index
-                                categoryListVM.modifyNameAlertIsPresented = true
-                            }, onDelete: {
-                                categoryListVM.deletingIndex = index
-                                categoryListVM.deleteAlertIsPresented = true
-                            })
-                        }
+                
+                if categoryListVM.categoryVMs.isEmpty {
+                    VStack {
+                        Spacer()
+                        Text(categoryListVM.searchText.isEmpty ?
+                             "카테고리가 존재하지 않습니다." : "검색어에 해당하는 카테고리가 존재하지 않습니다.")
+                            .padding(.bottom, 100)
+                        Spacer()
                     }
-                    .padding(.horizontal, 16)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 20) {
+                            ForEach(categoryListVM.enumeratedCategoryVMs, id: \.0) { index, categoryVM in
+                                CategoryRow(categoryVM: categoryVM, onModify: {
+                                    categoryListVM.modifyingIndex = index
+                                    categoryListVM.modifyNameAlertIsPresented = true
+                                }, onDelete: {
+                                    categoryListVM.deletingIndex = index
+                                    categoryListVM.deleteAlertIsPresented = true
+                                })
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                    }
                 }
             }
             .navigationTitle("카테고리 관리")

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -68,6 +68,7 @@ struct CategoryListView: View {
         })
         .alert("카테고리 이름 수정", isPresented: $categoryListVM.modifyNameAlertIsPresented, actions: {
             TextField("이름 입력", text: $categoryListVM.modifiedCategoryName)
+            
             Button("취소", role: .cancel) {
                 categoryListVM.modifyNameAlertIsPresented = false
             }
@@ -88,6 +89,8 @@ struct CategoryListView: View {
                 categoryListVM.modifyNameAlertIsPresented = false
                 categoryListVM.deleteCategory()
             }
+        }, message: {
+            Text("정말로 카테고리를 삭제하시겠습니까?")
         })
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -8,23 +8,34 @@
 import SwiftUI
 
 struct CategoryListView: View {
-    @State private var searchText = ""
+    @StateObject private var categoryListVM = CategoryListViewModel()
     
     var body: some View {
         NavigationView {
             VStack(spacing: 20) {
-                CustomSearchBar(searchText: $searchText, placeholder: "제목으로 검색")
+                CustomSearchBar(searchText: $categoryListVM.searchText, placeholder: "제목으로 검색")
                     .padding(.horizontal, 16)
                 ScrollView {
                     VStack(spacing: 20) {
-                        
+                        ForEach(categoryListVM.categoryVMs) { categoryVM in
+                            CategoryRow(categoryVM: categoryVM, onModify: {}, onDelete: {})
+                        }
                     }
                     .padding(.horizontal, 16)
                 }
             }
-
             .navigationTitle("카테고리 관리")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        categoryListVM.addCategories(named: "categoryEx")
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+
+                }
+            }
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
@@ -37,6 +37,9 @@ class CategoryListViewModel: ObservableObject {
         }
     }
     
+    var deletingIndex = 0
+    @Published var deleteAlertIsPresented = false
+    
     func showFilteredCategories() {
         do {
             categoryVMs = try Category.by(searchText: searchText).map(CategoryViewModel.init)
@@ -76,6 +79,16 @@ class CategoryListViewModel: ObservableObject {
             try categoryVMs[modifyingIndex].modifyName(to: modifiedCategoryName)
         } catch {
             errorMessage = "카테고리 이름을 수정하는데 실패했습니다."
+            CoreDataManager.shared.viewContext.rollback()
+        }
+    }
+    
+    func deleteCategory() {
+        do {
+            try categoryVMs[deletingIndex].delete()
+            categoryVMs.remove(at: deletingIndex)
+        } catch {
+            errorMessage = "카테고리를 제거하는데 실패했습니다."
             CoreDataManager.shared.viewContext.rollback()
         }
     }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  CategoryListViewModel.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/06.
+//
+
+import Foundation
+
+class CategoryListViewModel: ObservableObject {
+    @Published var categoryVMs = [CategoryViewModel]()
+    @Published var errorAlertIsPresented = false
+    
+    @Published var searchText = "" {
+        didSet {
+            showFilteredCategories()
+        }
+    }
+    
+    @Published var errorMessage = "" {
+        didSet {
+            errorAlertIsPresented = true
+        }
+    }
+    
+    func showFilteredCategories() {
+        do {
+            categoryVMs = try Category.by(searchText: searchText).map(CategoryViewModel.init)
+        } catch {
+            errorMessage = "카테고리들을 불러오는데 에러가 발생했습니다."
+        }
+    }
+    
+    func showAllCategories() {
+        do {
+            categoryVMs = try Category.all().map(CategoryViewModel.init)
+        } catch {
+            errorMessage = "카테고리들을 불러오는데 에러가 발생했습니다."
+        }
+    }
+    
+    func addCategories(named name: String) {
+        do {
+            let newCategory = Category(context: CoreDataManager.shared.viewContext)
+            newCategory.name = name
+            
+            try CoreDataManager.shared.viewContext.save()
+            showFilteredCategories()
+        } catch {
+            CoreDataManager.shared.viewContext.rollback()
+        }
+    }
+}

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
@@ -13,6 +13,15 @@ class CategoryListViewModel: ObservableObject {
         Array(categoryVMs.enumerated())
     }
     
+    @Published var newCategoryName = ""
+    @Published var addCategoryAlertIsPresented = false {
+        didSet {
+            if addCategoryAlertIsPresented {
+                newCategoryName = ""
+            }
+        }
+    }
+    
     @Published var errorAlertIsPresented = false
     
     var modifyingIndex = 0
@@ -56,10 +65,10 @@ class CategoryListViewModel: ObservableObject {
         }
     }
     
-    func addCategories(named name: String) {
+    func addCategory() {
         do {
             let newCategory = Category(context: CoreDataManager.shared.viewContext)
-            newCategory.name = name
+            newCategory.name = newCategoryName
             
             try CoreDataManager.shared.viewContext.save()
             showFilteredCategories()

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryRow.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryRow.swift
@@ -1,0 +1,45 @@
+//
+//  CategoryRow.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/05.
+//
+
+import SwiftUI
+
+struct CategoryRow: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(alignment: .center) {
+                Text("카테고리 1")
+                    .font(.system(size: 22, weight: .bold))
+                Spacer()
+                Text("9문제")
+            }
+            
+            HStack(spacing: 13) {
+                Spacer()
+                Image(systemName: "pencil.circle")
+                    .font(.system(size: 20))
+                    .foregroundColor(.blue)
+                Image(systemName: "trash.circle")
+                    .font(.system(size: 20))
+                    .foregroundColor(.red)
+            }
+        }
+        .padding(.vertical, 15)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke()
+                .foregroundColor(Color(.systemGray5))
+        )
+    }
+}
+
+struct CategoryRow_Previews: PreviewProvider {
+    static var previews: some View {
+        CategoryRow()
+            .padding(.horizontal, 16)
+    }
+}

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryRow.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryRow.swift
@@ -8,23 +8,31 @@
 import SwiftUI
 
 struct CategoryRow: View {
+    let categoryVM: CategoryViewModel
+    let onModify: () -> Void
+    let onDelete: () -> Void
+    
     var body: some View {
         VStack(spacing: 10) {
             HStack(alignment: .center) {
-                Text("카테고리 1")
+                Text(categoryVM.name)
                     .font(.system(size: 22, weight: .bold))
                 Spacer()
-                Text("9문제")
+                Text("\(categoryVM.numberOfProblems)문제")
             }
             
             HStack(spacing: 13) {
                 Spacer()
-                Image(systemName: "pencil.circle")
-                    .font(.system(size: 20))
-                    .foregroundColor(.blue)
-                Image(systemName: "trash.circle")
-                    .font(.system(size: 20))
-                    .foregroundColor(.red)
+                Button(action: onModify) {
+                    Image(systemName: "pencil.circle")
+                        .font(.system(size: 20))
+                        .foregroundColor(.blue)
+                }
+                Button(action: onDelete) {
+                    Image(systemName: "trash.circle")
+                        .font(.system(size: 20))
+                        .foregroundColor(.red)
+                }
             }
         }
         .padding(.vertical, 15)
@@ -34,12 +42,5 @@ struct CategoryRow: View {
                 .stroke()
                 .foregroundColor(Color(.systemGray5))
         )
-    }
-}
-
-struct CategoryRow_Previews: PreviewProvider {
-    static var previews: some View {
-        CategoryRow()
-            .padding(.horizontal, 16)
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
@@ -6,9 +6,18 @@
 //
 
 import Foundation
+import CoreData
 
-struct CategoryViewModel {
+struct CategoryViewModel: Identifiable {
     private let category: Category
+    
+    init(category: Category) {
+        self.category = category
+    }
+    
+    var id: NSManagedObjectID {
+        category.objectID
+    }
     
     var name: String {
         category.name ?? ""

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 
 struct CategoryViewModel: Identifiable {
-    private let category: Category
+    private var category: Category
     
     init(category: Category) {
         self.category = category
@@ -25,5 +25,19 @@ struct CategoryViewModel: Identifiable {
     
     var numberOfProblems: Int {
         category.problems?.count ?? 0
+    }
+    
+    mutating func modifyName(to newName: String) throws {
+        category.name = newName
+        
+        try CoreDataManager.shared.viewContext.save()
+        
+        category = try Category.by(id: id) as! Category
+    }
+    
+    func delete() throws {
+        category.delete()
+        
+        try CoreDataManager.shared.viewContext.save()
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  CategoryViewModel.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/05.
+//
+
+import Foundation
+
+struct CategoryViewModel {
+    private let category: Category
+    
+    var name: String {
+        category.name ?? ""
+    }
+    
+    var numberOfProblems: Int {
+        category.problems?.count ?? 0
+    }
+}

--- a/LifeWrongAnswerNote/Views/Components/CustomSearchBar.swift
+++ b/LifeWrongAnswerNote/Views/Components/CustomSearchBar.swift
@@ -1,0 +1,42 @@
+//
+//  CustomSearchBar.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/05.
+//
+
+import SwiftUI
+
+struct CustomSearchBar: View {
+    @Binding var searchText: String
+    let placeholder: String
+    
+    var body: some View {
+        HStack {
+            Image(systemName: "magnifyingglass").foregroundColor(.gray)
+            TextField(placeholder, text: $searchText)
+            Spacer(minLength: 0)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(Color(.systemGray2))
+                        .frame(width: 8, height: 8)
+                        .padding(.trailing, 4)
+                }
+                
+            }
+        }
+        .padding(.vertical, 7)
+        .padding(.horizontal, 4)
+        .background(RoundedRectangle(cornerRadius: 10).foregroundColor(Color(UIColor.systemGray6)))
+    }
+}
+
+struct CustomSearchBar_Previews: PreviewProvider {
+    static var previews: some View {
+        CustomSearchBar(searchText: .constant(""), placeholder: "제목으로 검색")
+            .padding(.horizontal, 16)
+    }
+}


### PR DESCRIPTION
1. `CategoryViewModel`
    
    * `Category`를 감싸주는 역할
    * `name`, `numberOfProblems` 프로퍼티로 view에 정보 제공
    * `modifyName(to:)`: 이름 수정 후 fetch request로 category를 다시 불러옴
        * Core Data Entity는 클래스이기 때문에 변화가 view에 반영되려면 새로 불러와야 함
    * `delete()`: `Category` entity를 제거

2. `CategoryListViewModel`

    * `Category`의 CRUD를 담당
    * 수정, 삭제의 경우 index를 설정해 놓은 다음 `modifyName()`, `deleteCategory()`를 호출
    * 처음에는 `showAllCategories()` 통해 모든 카테고리 보여줌
    * 검색어 수정 시 `showFilteredCategories()` 호출하여 필터링한 결과 보여줌

3. `CategoryRow`

    * `CategoryViewModel`를 받아서 카테고리 정보를 나타내는 view
    * `onModify`와 `onDelete` 클로저를 받아서 수정, 삭제 action 실행

4. `CategoryListView`

    * `CategoryListViewModel`을 받아서 각 카테고리에 대한 CRUD 작업 수행
    * 3개의 alert는 추가, 수정, 삭제 시 alert 보여주는 역할
    * 1개의 alert는 에러 발생 시 에러 메시지 보여주는 역할