### PR TITLE
ProblemListViewModel 구현 및 ProblemListView에 적용

### DIFF
--- a/LifeWrongAnswerNote.xcodeproj/project.pbxproj
+++ b/LifeWrongAnswerNote.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		AB39317C293CB41D0051454D /* Assessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39317B293CB41D0051454D /* Assessment.swift */; };
 		AB39317E293CCB300051454D /* Choice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39317D293CCB300051454D /* Choice+.swift */; };
 		AB393182293CCB6A0051454D /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB393181293CCB6A0051454D /* ChoiceTests.swift */; };
+		AB4F1F0C2944BD1E001C11F1 /* ProblemListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4F1F0B2944BD1E001C11F1 /* ProblemListViewModel.swift */; };
 		AB5AB0F5293E01CE0023E453 /* CategoryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */; };
 		AB5AB0FA293E27340023E453 /* CustomSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */; };
 		AB5AB0FC293E28F80023E453 /* CategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5AB0FB293E28F80023E453 /* CategoryListView.swift */; };
@@ -74,6 +75,7 @@
 		AB39317B293CB41D0051454D /* Assessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assessment.swift; sourceTree = "<group>"; };
 		AB39317D293CCB300051454D /* Choice+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Choice+.swift"; sourceTree = "<group>"; };
 		AB393181293CCB6A0051454D /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
+		AB4F1F0B2944BD1E001C11F1 /* ProblemListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemListViewModel.swift; sourceTree = "<group>"; };
 		AB5AB0F4293E01CE0023E453 /* CategoryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryRow.swift; sourceTree = "<group>"; };
 		AB5AB0F9293E27340023E453 /* CustomSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchBar.swift; sourceTree = "<group>"; };
 		AB5AB0FB293E28F80023E453 /* CategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListView.swift; sourceTree = "<group>"; };
@@ -206,8 +208,9 @@
 		AB99C7082940B8470011F51B /* ProblemListView */ = {
 			isa = PBXGroup;
 			children = (
-				AB1F33212941D0BE00B1D217 /* ProblemViewModel.swift */,
+				AB4F1F0B2944BD1E001C11F1 /* ProblemListViewModel.swift */,
 				AB99C70F2940BF680011F51B /* ProblemListView.swift */,
+				AB1F33212941D0BE00B1D217 /* ProblemViewModel.swift */,
 				AB99C70B2940B87F0011F51B /* ProblemRow.swift */,
 			);
 			path = ProblemListView;
@@ -340,6 +343,7 @@
 				AB99C7172940D4240011F51B /* ChoiceRow.swift in Sources */,
 				AB99C7152940D0E20011F51B /* BorderedTextEditor.swift in Sources */,
 				AB99C70C2940B87F0011F51B /* ProblemRow.swift in Sources */,
+				AB4F1F0C2944BD1E001C11F1 /* ProblemListViewModel.swift in Sources */,
 				AB204299293B93940086DA36 /* CoreDataManager.swift in Sources */,
 				AB99C7192940DDA90011F51B /* ProblemDetailView.swift in Sources */,
 				AB99C70E2940BC000011F51B /* MenuLabel.swift in Sources */,

--- a/LifeWrongAnswerNote/LifeWrongAnswerNoteApp.swift
+++ b/LifeWrongAnswerNote/LifeWrongAnswerNoteApp.swift
@@ -15,7 +15,7 @@ struct LifeWrongAnswerNoteApp: App {
     
     var body: some Scene {
         WindowGroup {
-            CategoryListView()
+            ProblemListView()
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -55,19 +55,9 @@ struct CategoryListView: View {
         .onAppear {
             categoryListVM.showAllCategories()
         }
-        .alert("카테고리 추가", isPresented: $categoryListVM.addCategoryAlertIsPresented, actions: {
-            TextField("이름 입력", text: $categoryListVM.newCategoryName)
-            Button("추가") {
-                categoryListVM.addCategoryAlertIsPresented = false
-                categoryListVM.addCategory()
-            }
-            
-            Button("취소", role: .cancel) {
-                categoryListVM.addCategoryAlertIsPresented = false
-            }
-        }, message: {
-            Text("새롭게 추가할 카테고리의 이름을 입력하세요.")
-        })
+        .modifier(categoryListVM.addCategoryAlert(presented: $categoryListVM.addCategoryAlertIsPresented))
+        .modifier(categoryListVM.modifyCategoryAlert(presented: $categoryListVM.modifyNameAlertIsPresented))
+        .modifier(categoryListVM.deleteCategoryAlert(presented: $categoryListVM.deleteAlertIsPresented))
         .alert("에러 발생", isPresented: $categoryListVM.errorAlertIsPresented, actions: {
             Button("확인") {
                 categoryListVM.errorAlertIsPresented = false
@@ -75,8 +65,6 @@ struct CategoryListView: View {
         }, message: {
             Text(categoryListVM.errorMessage)
         })
-        .modifier(categoryListVM.modifyCategoryAlert(presented: $categoryListVM.modifyNameAlertIsPresented))
-        .modifier(categoryListVM.deleteCategoryAlert(presented: $categoryListVM.deleteAlertIsPresented))
     }
 }
 

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -29,8 +29,7 @@ struct CategoryListView: View {
                         VStack(spacing: 20) {
                             ForEach(categoryListVM.enumeratedCategoryVMs, id: \.0) { index, categoryVM in
                                 CategoryRow(categoryVM: categoryVM, onModify: {
-                                    categoryListVM.modifyingIndex = index
-                                    categoryListVM.modifyNameAlertIsPresented = true
+                                    categoryListVM.alertAndModifyCategory(at: index)
                                 }, onDelete: {
                                     categoryListVM.deletingIndex = index
                                     categoryListVM.deleteAlertIsPresented = true
@@ -77,20 +76,7 @@ struct CategoryListView: View {
         }, message: {
             Text(categoryListVM.errorMessage)
         })
-        .alert("카테고리 이름 수정", isPresented: $categoryListVM.modifyNameAlertIsPresented, actions: {
-            TextField("이름 입력", text: $categoryListVM.modifiedCategoryName)
-            
-            Button("취소", role: .cancel) {
-                categoryListVM.modifyNameAlertIsPresented = false
-            }
-            
-            Button("수정") {
-                categoryListVM.modifyNameAlertIsPresented = false
-                categoryListVM.modifyName()
-            }
-        }, message: {
-            Text("카테고리의 새 이름을 입력하세요.")
-        })
+        .modifier(categoryListVM.modifyCategoryAlert(presented: $categoryListVM.modifyNameAlertIsPresented))
         .alert("카테고리 제거", isPresented: $categoryListVM.deleteAlertIsPresented, actions: {
             Button("취소", role: .cancel, action: {
                 categoryListVM.modifyNameAlertIsPresented = false

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListView.swift
@@ -31,8 +31,7 @@ struct CategoryListView: View {
                                 CategoryRow(categoryVM: categoryVM, onModify: {
                                     categoryListVM.alertAndModifyCategory(at: index)
                                 }, onDelete: {
-                                    categoryListVM.deletingIndex = index
-                                    categoryListVM.deleteAlertIsPresented = true
+                                    categoryListVM.alertAndDeleteCategory(at: index)
                                 })
                             }
                         }
@@ -77,18 +76,7 @@ struct CategoryListView: View {
             Text(categoryListVM.errorMessage)
         })
         .modifier(categoryListVM.modifyCategoryAlert(presented: $categoryListVM.modifyNameAlertIsPresented))
-        .alert("카테고리 제거", isPresented: $categoryListVM.deleteAlertIsPresented, actions: {
-            Button("취소", role: .cancel, action: {
-                categoryListVM.modifyNameAlertIsPresented = false
-            })
-            
-            Button("제거", role: .destructive) {
-                categoryListVM.modifyNameAlertIsPresented = false
-                categoryListVM.deleteCategory()
-            }
-        }, message: {
-            Text("정말로 카테고리를 삭제하시겠습니까?")
-        })
+        .modifier(categoryListVM.deleteCategoryAlert(presented: $categoryListVM.deleteAlertIsPresented))
     }
 }
 

--- a/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/CategoryListView/CategoryListViewModel.swift
@@ -14,15 +14,6 @@ class CategoryListViewModel: ObservableObject {
         Array(categoryVMs.enumerated())
     }
     
-    @Published var newCategoryName = ""
-    @Published var addCategoryAlertIsPresented = false {
-        didSet {
-            if addCategoryAlertIsPresented {
-                newCategoryName = ""
-            }
-        }
-    }
-    
     @Published var searchText = "" {
         didSet {
             showFilteredCategories()
@@ -50,6 +41,36 @@ class CategoryListViewModel: ObservableObject {
         } catch {
             errorMessage = "카테고리들을 불러오는데 에러가 발생했습니다."
         }
+    }
+    
+    // MARK: - 추가 alert
+    @Published var newCategoryName = ""
+    @Published var addCategoryAlertIsPresented = false {
+        didSet {
+            if addCategoryAlertIsPresented {
+                newCategoryName = ""
+            }
+        }
+    }
+    
+    private func addCategory(named name: String) {
+        do {
+            let newCategory = Category(context: CoreDataManager.shared.viewContext)
+            newCategory.name = name
+            
+            try CoreDataManager.shared.viewContext.save()
+            showFilteredCategories()
+        } catch {
+            errorMessage = "카테고리를 추가하는데 실패하였습니다."
+            CoreDataManager.shared.viewContext.rollback()
+        }
+    }
+    
+    func addCategoryAlert(presented: Binding<Bool>) -> AlertModifierWithTextField {
+        return AlertModifierWithTextField(presented: presented,
+                                          title: "카테고리 추가",
+                                          message: "새롭게 추가할 카테고리 이름을 입력하세요.",
+                                          okMessage: "추가", action: addCategory(named:))
     }
     
     // MARK: - 수정 alert
@@ -116,18 +137,5 @@ class CategoryListViewModel: ObservableObject {
     func alertAndDeleteCategory(at index: Int) {
         deletingIndex = index
         deleteAlertIsPresented = true
-    }
-    
-    func addCategory() {
-        do {
-            let newCategory = Category(context: CoreDataManager.shared.viewContext)
-            newCategory.name = newCategoryName
-            
-            try CoreDataManager.shared.viewContext.save()
-            showFilteredCategories()
-        } catch {
-            errorMessage = "카테고리를 추가하는데 실패하였습니다."
-            CoreDataManager.shared.viewContext.rollback()
-        }
     }
 }

--- a/LifeWrongAnswerNote/Views/Components/AlertModifierWithTextField.swift
+++ b/LifeWrongAnswerNote/Views/Components/AlertModifierWithTextField.swift
@@ -20,7 +20,7 @@ struct AlertModifierWithTextField: ViewModifier {
     func body(content: Content) -> some View {
         content
             .alert(title, isPresented: $presented, actions: {
-                TextField("선택지 이름", text: $input)
+                TextField("입력", text: $input)
                 Button("취소", role: .cancel) {
                     presented = false
                     input = ""

--- a/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
@@ -15,7 +15,7 @@ struct ProblemDetailView: View {
     
     init(problemVM: ProblemViewModel?) {
         self._problemDetailVM = StateObject(wrappedValue: ProblemDetailViewModel(problemVM: problemVM))
-        self._isEditing.wrappedValue = problemVM == nil
+        self._isEditing = State(initialValue: problemVM == nil)
     }
     
     var body: some View {

--- a/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
@@ -19,45 +19,43 @@ struct ProblemDetailView: View {
     }
     
     var body: some View {
-        NavigationView {
-            TabView {
-                summaryView
-                titleView
-                choicesView
-                reasonView
-                resultView
-                lessonView
+        TabView {
+            summaryView
+            titleView
+            choicesView
+            reasonView
+            resultView
+            lessonView
+        }
+        .tabViewStyle(PageTabViewStyle())
+        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
+        .navigationTitle("문제 수정")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            categoryListVM.showAllCategories()
+        }
+        .modifier(problemDetailVM.addChoiceAlert(presented: $problemDetailVM.addChoiceAlertIsPresented))
+        .modifier(problemDetailVM.modifyChoiceAlert(presented: $problemDetailVM.modifyChoiceAlertIsPresented))
+        .modifier(problemDetailVM.deleteChoiceAlert(presented: $problemDetailVM.deleteChoiceAlertIsPresented))
+        .alert("에러 발생", isPresented: $problemDetailVM.errorAlertIsPresented, actions: {
+            Button("확인") {
+                problemDetailVM.errorAlertIsPresented = false
             }
-            .tabViewStyle(PageTabViewStyle())
-            .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
-            .navigationTitle("문제 수정")
-            .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
-                categoryListVM.showAllCategories()
-            }
-            .modifier(problemDetailVM.addChoiceAlert(presented: $problemDetailVM.addChoiceAlertIsPresented))
-            .modifier(problemDetailVM.modifyChoiceAlert(presented: $problemDetailVM.modifyChoiceAlertIsPresented))
-            .modifier(problemDetailVM.deleteChoiceAlert(presented: $problemDetailVM.deleteChoiceAlertIsPresented))
-            .alert("에러 발생", isPresented: $problemDetailVM.errorAlertIsPresented, actions: {
-                Button("확인") {
-                    problemDetailVM.errorAlertIsPresented = false
-                }
-            }, message: {
-                Text(problemDetailVM.errorMessage)
-            })
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        if isEditing {
-                            problemDetailVM.saveProblem()
-                        }
-                        
-                        isEditing.toggle()
-                    } label: {
-                        Image(systemName: isEditing ? "checkmark" : "pencil")
+        }, message: {
+            Text(problemDetailVM.errorMessage)
+        })
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    if isEditing {
+                        problemDetailVM.saveProblem()
                     }
-
+                    
+                    isEditing.toggle()
+                } label: {
+                    Image(systemName: isEditing ? "checkmark" : "pencil")
                 }
+                
             }
         }
     }
@@ -181,6 +179,8 @@ struct ProblemDetailView: View {
 
 struct ProblemDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProblemDetailView(problemVM: nil)
+        NavigationView {
+            ProblemDetailView(problemVM: nil)
+        }
     }
 }

--- a/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailView.swift
@@ -59,10 +59,6 @@ struct ProblemDetailView: View {
 
                 }
             }
-            .onDisappear {
-                CoreDataManager.shared.viewContext.rollback()
-                presentationMode.wrappedValue.dismiss()
-            }
         }
     }
     

--- a/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailViewModel.swift
+++ b/LifeWrongAnswerNote/Views/ProblemDetailView/ProblemDetailViewModel.swift
@@ -18,18 +18,33 @@ class ProblemDetailViewModel: ObservableObject {
     }
     
     init(problemVM: ProblemViewModel?) {
-        problem = problemVM?.problem ?? Problem(context: CoreDataManager.shared.viewContext)
-        
-        if problemVM == nil {
-            problem.createdDate = .now
-        }
-        
-        do {
-            tempChoices = try Choice.by(problem: problem).map { choice in
-                return TempChoice(content: choice.content ?? "", isSelected: choice.isSelected)
+        if let problemVM {
+            problem = problemVM.problem
+            
+            _title = Published(initialValue: problem.title ?? "")
+            
+            if let category = problem.category {
+                _categoryVM = Published(initialValue: CategoryViewModel(category: category))
             }
-        } catch {
-            errorMessage = "문제의 세부 정보를 불러오는데 실패했습니다.\n화면을 나갔다가 다시 들어오세요."
+            
+            _isFinished = Published(initialValue: problem.finished)
+            _assessment = Published(initialValue: problem.assessment)
+            _situation = Published(initialValue: problem.situation ?? "")
+            _reason = Published(initialValue: problem.reason ?? "")
+            _result = Published(initialValue: problem.result ?? "")
+            _lesson = Published(initialValue: problem.lesson ?? "")
+            
+            do {
+                _tempChoices = Published(initialValue: try Choice.by(problem: problem).map { choice in
+                    return TempChoice(content: choice.content ?? "", isSelected: choice.isSelected)
+                })
+            } catch {
+                _errorMessage = Published(initialValue: "문제의 세부 정보를 불러오는데 실패했습니다.\n화면을 나갔다가 다시 들어오세요.")
+                _errorAlertIsPresented = Published(initialValue: true)
+            }
+        } else {
+            problem = Problem(context: CoreDataManager.shared.viewContext)
+            problem.createdDate = .now
         }
     }
     

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
@@ -15,17 +15,44 @@ struct ProblemListView: View {
         NavigationView {
             VStack(spacing: 18) {
                 HStack(spacing: 16) {
-                    MenuLabel(isClickable: true) {
-                        Text("카테고리")
-                            .font(.system(size: 14))
+                    Menu {
+                        Button("전체") {
+                            problemListVM.categoryVM = nil
+                        }
+                        
+                        ForEach(categoryListVM.categoryVMs, id: \.id) { categoryVM in
+                            Button(categoryVM.name) {
+                                problemListVM.categoryVM = categoryVM
+                            }
+                        }
+                    } label: {
+                        MenuLabel(isClickable: true) {
+                            Text(problemListVM.categoryVM?.name ?? "카테고리")
+                                .font(.system(size: 14))
+                        }
                     }
-                    MenuLabel(isClickable: true) {
-                        Text("진행상태")
-                            .font(.system(size: 14))
+
+                    Menu {
+                        Button("전체") {
+                            problemListVM.isFinished = nil
+                        }
+                        
+                        ForEach([false, true], id: \.self) { isFinished in
+                            Button(isFinished ? "완료" : "진행 중") {
+                                problemListVM.isFinished = isFinished
+                            }
+                        }
+                    } label: {
+                        MenuLabel(isClickable: true) {
+                            Text(problemListVM.isFinishedText)
+                                .font(.system(size: 14))
+                        }
                     }
+
                     Spacer()
                 }
                 .padding(.horizontal, 16)
+                .tint(Color(.label))
                 
                 CustomSearchBar(searchText: $problemListVM.searchText, placeholder: "제목으로 검색")
                     .padding(.horizontal, 16)

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct ProblemListView: View {
-    @State private var searchText = ""
+    @StateObject private var problemListVM = ProblemListViewModel()
+    @StateObject private var categoryListVM = CategoryListViewModel()
     
     var body: some View {
         NavigationView {
@@ -26,13 +27,13 @@ struct ProblemListView: View {
                 }
                 .padding(.horizontal, 16)
                 
-                CustomSearchBar(searchText: $searchText, placeholder: "제목으로 검색")
+                CustomSearchBar(searchText: $problemListVM.searchText, placeholder: "제목으로 검색")
                     .padding(.horizontal, 16)
                 
                 ScrollView {
                     VStack(spacing: 20) {
-                        ForEach(0..<10) { _ in
-                            ProblemRow()
+                        ForEach(problemListVM.enumeratedProblemVMs, id: \.0) { index, problemVM in
+                            ProblemRow(problemVM: problemVM)
                         }
                     }
                     .padding(.horizontal, 16)
@@ -40,6 +41,10 @@ struct ProblemListView: View {
             }
             .navigationTitle("문제 목록")
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                problemListVM.showFilteredProblems()
+                categoryListVM.showAllCategories()
+            }
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
@@ -81,6 +81,13 @@ struct ProblemListView: View {
                     }
                 }
             }
+            .alert("에러 발생", isPresented: $problemListVM.errorAlertIsPresented, actions: {
+                Button("확인") {
+                    problemListVM.errorAlertIsPresented = false
+                }
+            }, message: {
+                Text(problemListVM.errorMessage)
+            })
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListView.swift
@@ -45,6 +45,15 @@ struct ProblemListView: View {
                 problemListVM.showFilteredProblems()
                 categoryListVM.showAllCategories()
             }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink {
+                        ProblemDetailView(problemVM: nil)
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
         }
     }
 }

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
@@ -41,8 +41,14 @@ class ProblemListViewModel: ObservableObject {
     
     func showFilteredProblems() {
         do {
-            problemVMs = try Problem.by(category: categoryVM?.category, isFinished: isFinished, searchText: searchText)
+            problemVMs = []
+            
+            let filteredResult = try Problem.by(category: categoryVM?.category, isFinished: isFinished, searchText: searchText)
                 .map(ProblemViewModel.init(problem:))
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.problemVMs = filteredResult
+            }
         } catch {
             errorMessage = "문제 목록을 가져오는데 실패하였습니다."
         }

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
@@ -24,6 +24,14 @@ class ProblemListViewModel: ObservableObject {
             showFilteredProblems()
         }
     }
+    var isFinishedText: String {
+        if let isFinished {
+            return isFinished ? "완료" : "진행 중"
+        } else {
+            return "진행상태"
+        }
+    }
+    
     @Published var searchText = "" {
         didSet {
             showFilteredProblems()

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemListViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  ProblemListViewModel.swift
+//  LifeWrongAnswerNote
+//
+//  Created by 김남건 on 2022/12/10.
+//
+
+import Foundation
+import CoreData
+
+class ProblemListViewModel: ObservableObject {
+    @Published var problemVMs = [ProblemViewModel]()
+    var enumeratedProblemVMs: [(Int, ProblemViewModel)] {
+        Array(problemVMs.enumerated())
+    }
+    
+    @Published var categoryVM: CategoryViewModel? {
+        didSet {
+            showFilteredProblems()
+        }
+    }
+    @Published var isFinished: Bool? {
+        didSet {
+            showFilteredProblems()
+        }
+    }
+    @Published var searchText = "" {
+        didSet {
+            showFilteredProblems()
+        }
+    }
+    
+    @Published var deletable = false
+    
+    @Published var errorAlertIsPresented = false
+    @Published var errorMessage = "" {
+        didSet {
+            errorAlertIsPresented = true
+        }
+    }
+    
+    func showFilteredProblems() {
+        do {
+            problemVMs = try Problem.by(category: categoryVM?.category, isFinished: isFinished, searchText: searchText)
+                .map(ProblemViewModel.init(problem:))
+        } catch {
+            errorMessage = "문제 목록을 가져오는데 실패하였습니다."
+        }
+    }
+}

--- a/LifeWrongAnswerNote/Views/ProblemListView/ProblemRow.swift
+++ b/LifeWrongAnswerNote/Views/ProblemListView/ProblemRow.swift
@@ -8,21 +8,22 @@
 import SwiftUI
 
 struct ProblemRow: View {
+    let problemVM: ProblemViewModel
+    
     var body: some View {
-        NavigationLink(destination: Text("Hello")) {
+        NavigationLink(destination: ProblemDetailView(problemVM: problemVM)) {
             VStack(spacing: 5) {
                 HStack(alignment: .center) {
-                    Text("제목 1")
+                    Text(problemVM.title)
                         .font(.system(size: 22, weight: .bold))
                     Spacer()
-                    Image(systemName: "checkmark.circle")
-                        .foregroundColor(.green)
+                    problemVM.assessment.image
                         .font(.system(size: 25))
                 }
                 HStack {
-                    Text("카테고리1 / 진행 중")
+                    Text("\(problemVM.categoryName) / \(problemVM.finishedInfo)")
                     Spacer()
-                    Text("2022.12.07")
+                    Text(problemVM.dateString)
                         .foregroundColor(Color(.systemGray2))
                 }
             }
@@ -34,14 +35,6 @@ struct ProblemRow: View {
                     .foregroundColor(Color(.systemGray5))
             )
             .foregroundColor(Color(.label))
-        }
-    }
-}
-
-struct ProblemRow_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            ProblemRow()
         }
     }
 }


### PR DESCRIPTION
1. `ProblemRow`
    
    * `ProblemViewModel`을 프로퍼티로 받아서 문제 정보들을 보여주도록 함

2. `ProblemListViewModel`

    * `searchText`, `isFinished`, `categoryVM` 등의 `@Published` 프로퍼티 저장
    * 그에 따라 `problemVMs`를 초기화하여 필터링된 문제 목록 보여줌

3. `ProblemDetailViewModel`

    * 기존 문제 조회 시 수정 모드로 열리는 버그 수정